### PR TITLE
feat(azure): ACA single-ingress deployment + docs

### DIFF
--- a/.github/workflows/aca-deploy.yml
+++ b/.github/workflows/aca-deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy ACA (single region)
+
+on:
+  workflow_dispatch:
+    inputs:
+      rocketchat_tag:
+        description: "Rocket.Chat image tag (e.g., 7.9.2)"
+        required: true
+        default: "7.9.2"
+
+permissions:
+  id-token: write   # OIDC for azure/login
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy ACA stack (UK South)
+        env:
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+        run: |
+          bash azure/deploy-aca.sh "${{ inputs.rocketchat_tag }}"
+
+      - name: Show Rocket.Chat FQDN
+        run: |
+          az containerapp show -g Rocketchat_RG -n rocketchat --query properties.configuration.ingress.fqdn -o tsv || true

--- a/.github/workflows/aca-update-rocketchat.yml
+++ b/.github/workflows/aca-update-rocketchat.yml
@@ -1,0 +1,48 @@
+name: Update Rocket.Chat in ACA
+
+on:
+  workflow_dispatch:
+    inputs:
+      rocketchat_tag:
+        description: "Rocket.Chat image tag to deploy (e.g., 7.9.3)"
+        required: true
+        default: "7.9.3"
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Determine Rocket.Chat tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Expect release tag like rc-7.9.3 or v7.9.3; extract version
+            ver=$(echo "${{ github.event.release.tag_name }}" | sed -E 's/^rc-|^v-?|^v//')
+            echo "tag=$ver" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.rocketchat_tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Rocket.Chat to tag
+        run: |
+          bash azure/update-rocketchat.sh "${{ steps.tag.outputs.tag }}"
+
+      - name: Print revisions
+        run: |
+          az containerapp revision list -g Rocketchat_RG -n rocketchat -o table || true

--- a/README.md
+++ b/README.md
@@ -164,6 +164,37 @@ curl -I http://YOUR_SERVER_IP
 
 ---
 
+## 🌐 Deploy to Azure Container Apps (ACA)
+
+A production-ready, single-region ACA deployment is included. It uses a single public ingress on `rocketchat` and keeps `grafana` internal (served via `/grafana` path).
+
+### Prerequisites
+- Azure CLI logged in on a machine that can access your subscription
+- Resource group: `Rocketchat_RG` (existing is fine)
+
+### One-command deploy
+```bash
+# From repo root
+export GRAFANA_ADMIN_PASSWORD='your-strong-secret'
+./azure/deploy-aca.sh
+```
+This will:
+- Deploy `azure/main.bicep` to `uksouth`
+- Create/resolve ACR and import required images
+- Run the one-time MongoDB init Job
+- Try to add the `/grafana` route to the internal Grafana app
+- Print the public FQDN for Rocket.Chat
+
+### DNS (Cloudflare)
+- Create a CNAME: `chat.canepro.me` → printed ACA FQDN (orange-cloud/proxied OK)
+
+### Notes
+- Path-based routing lives on the `rocketchat` app. If your CLI doesn’t support HTTP routes yet, add the route in Azure Portal after deploy.
+- Grafana’s admin password is stored as an ACA secret.
+- Node Exporter is intentionally omitted (not applicable to serverless).
+
+---
+
 **To stop:**
 ```bash
 make down

--- a/azure/MULTI_REGION_SETUP.md
+++ b/azure/MULTI_REGION_SETUP.md
@@ -1,0 +1,307 @@
+# 🌍 Multi-Region Container Apps Environment Setup
+
+## 📋 Overview
+
+This guide covers the setup of Azure Container Apps Environment with the **"Show environments in all regions"** option enabled, which provides better availability and disaster recovery capabilities.
+
+## 🎯 Benefits of Multi-Region Setup
+
+### ✅ **Availability**
+- **Geographic redundancy**: Services available across multiple regions
+- **Disaster recovery**: Automatic failover capabilities
+- **Reduced latency**: Users connect to nearest region
+- **Compliance**: Meet regional data residency requirements
+
+### ✅ **Performance**
+- **Global load balancing**: Traffic distributed across regions
+- **CDN integration**: Cloudflare can route to optimal region
+- **Reduced latency**: Faster response times for global users
+
+### ⚠️ **Considerations**
+- **Increased complexity**: More regions to manage
+- **Higher costs**: Resources in multiple regions
+- **Data synchronization**: Cross-region data consistency
+- **Configuration management**: Consistent settings across regions
+
+## 🏗️ **Setup Process**
+
+### **Step 1: Enable Multi-Region Option**
+
+When creating the Container Apps Environment in Azure Portal:
+
+1. **Navigate to**: Container Apps Environment creation
+2. **Check**: "Show environments in all regions" checkbox
+3. **Select regions**: Choose primary and secondary regions
+   - **Primary**: West US 2 (recommended)
+   - **Secondary**: East US 2 (for redundancy)
+
+### **Step 2: Region Selection Strategy**
+
+```yaml
+# Recommended Region Configuration
+Primary Region: West US 2
+  - Lower latency for US West Coast
+  - Good for demo and testing
+  - Cost-effective
+
+Secondary Region: East US 2
+  - Backup for disaster recovery
+  - Better for US East Coast users
+  - Compliance requirements
+
+Optional Regions:
+  - West Europe (EU users)
+  - Southeast Asia (APAC users)
+```
+
+### **Step 3: Resource Naming Convention**
+
+```bash
+# Multi-region naming convention
+Resource Group: Rocketchat_RG
+Environment Name: rocketchat-env-{region}
+  - rocketchat-env-westus2
+  - rocketchat-env-eastus2
+
+Container Apps:
+  - rocketchat-main-{region}
+  - grafana-monitoring-{region}
+  - mongo-database-{region}
+```
+
+## 🔧 **Bicep Template Modifications**
+
+### **Multi-Region Parameters**
+
+```bicep
+@description('Primary region for deployment')
+param primaryRegion string = 'westus2'
+
+@description('Secondary region for disaster recovery')
+param secondaryRegion string = 'eastus2'
+
+@description('Enable multi-region deployment')
+param enableMultiRegion bool = true
+
+@description('Regions to deploy to')
+param regions array = [
+  primaryRegion
+  secondaryRegion
+]
+```
+
+### **Loop Through Regions**
+
+```bicep
+// Deploy to multiple regions
+resource containerAppsEnvironments 'Microsoft.App/managedEnvironments@2023-05-01' = [for region in regions: {
+  name: 'rocketchat-env-${region}'
+  location: region
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspace.properties.customerId
+        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+      }
+    }
+  }
+}]
+```
+
+## 🌐 **Cloudflare Integration**
+
+### **DNS Configuration**
+
+```yaml
+# Multi-region DNS setup
+A Records:
+  - chat.canepro.me → Primary region IP
+  - chat.canepro.me → Secondary region IP (failover)
+
+CNAME Records:
+  - west.chat.canepro.me → Primary region
+  - east.chat.canepro.me → Secondary region
+
+Load Balancing:
+  - Enable Cloudflare Load Balancer
+  - Configure health checks
+  - Set up failover rules
+```
+
+### **Page Rules for Multi-Region**
+
+```yaml
+# Cloudflare Page Rules
+Rule 1:
+  URL: chat.canepro.me/*
+  Settings:
+    - Cache Level: Bypass
+    - Origin: Primary region
+
+Rule 2:
+  URL: west.chat.canepro.me/*
+  Settings:
+    - Cache Level: Bypass
+    - Origin: West US 2
+
+Rule 3:
+  URL: east.chat.canepro.me/*
+  Settings:
+    - Cache Level: Bypass
+    - Origin: East US 2
+```
+
+## 📊 **Monitoring & Health Checks**
+
+### **Azure Monitor Configuration**
+
+```yaml
+# Multi-region monitoring
+Application Insights:
+  - Primary region: West US 2
+  - Secondary region: East US 2
+  - Cross-region correlation
+
+Alerts:
+  - Region-specific health checks
+  - Cross-region availability monitoring
+  - Performance comparison alerts
+```
+
+### **Health Check Endpoints**
+
+```bash
+# Health check URLs for each region
+Primary Region:
+  - https://chat.canepro.me/health
+  - https://west.chat.canepro.me/health
+
+Secondary Region:
+  - https://east.chat.canepro.me/health
+  - https://chat.canepro.me/health (failover)
+```
+
+## 💰 **Cost Management**
+
+### **Multi-Region Cost Breakdown**
+
+```yaml
+Estimated Monthly Costs:
+  Primary Region (West US 2):
+    - Container Apps: $40-60
+    - Container Registry: $5-10
+    - Log Analytics: $5-10
+    - Total: $50-80
+
+  Secondary Region (East US 2):
+    - Container Apps: $40-60
+    - Container Registry: $5-10
+    - Log Analytics: $5-10
+    - Total: $50-80
+
+  Total Multi-Region: $100-160
+  Budget: $150/month
+  Status: ⚠️ Close to budget limit
+```
+
+### **Cost Optimization Strategies**
+
+1. **Start with Single Region**
+   - Deploy to primary region only
+   - Monitor usage and performance
+   - Add secondary region when needed
+
+2. **Right-size Resources**
+   - Optimize CPU/memory allocation
+   - Use appropriate scaling rules
+   - Monitor and adjust based on usage
+
+3. **Reserved Instances**
+   - Consider reserved capacity for predictable workloads
+   - Plan for long-term usage patterns
+
+## 🚀 **Deployment Strategy**
+
+### **Phase 1: Single Region**
+```bash
+# Start with primary region only
+./deploy.sh --region westus2 --single-region
+```
+
+### **Phase 2: Add Secondary Region**
+```bash
+# Add secondary region for redundancy
+./deploy.sh --region eastus2 --add-region
+```
+
+### **Phase 3: Multi-Region Load Balancing**
+```bash
+# Configure Cloudflare load balancing
+./configure-cloudflare.sh --enable-load-balancing
+```
+
+## 🔄 **Disaster Recovery**
+
+### **Failover Configuration**
+
+```yaml
+# Automatic failover setup
+Primary Region: West US 2
+  - Active: 100% traffic
+  - Health check: Every 30 seconds
+  - Failover threshold: 3 consecutive failures
+
+Secondary Region: East US 2
+  - Standby: 0% traffic
+  - Health check: Every 30 seconds
+  - Activation: Automatic on primary failure
+```
+
+### **Recovery Procedures**
+
+1. **Automatic Failover**
+   - Cloudflare detects primary region failure
+   - Traffic automatically routes to secondary region
+   - Health checks continue monitoring
+
+2. **Manual Failover**
+   - Admin initiates manual failover
+   - Traffic manually redirected
+   - Primary region investigation and recovery
+
+3. **Recovery Steps**
+   - Fix issues in primary region
+   - Verify health checks pass
+   - Gradually restore traffic to primary
+   - Monitor for stability
+
+## 📝 **Best Practices**
+
+### ✅ **Do's**
+- Start with single region deployment
+- Monitor costs closely
+- Test failover procedures regularly
+- Use consistent naming conventions
+- Document regional configurations
+
+### ❌ **Don'ts**
+- Don't deploy to all regions initially
+- Don't skip health check configuration
+- Don't ignore cost monitoring
+- Don't forget backup procedures
+- Don't skip documentation
+
+## 🎯 **Next Steps**
+
+1. **Start with single region** (West US 2)
+2. **Monitor performance and costs**
+3. **Add secondary region** when needed
+4. **Configure Cloudflare load balancing**
+5. **Test disaster recovery procedures**
+
+---
+
+**Status**: 📋 Planning Phase  
+**Priority**: Medium (after single region deployment)  
+**Estimated Effort**: 2-3 days for full multi-region setup

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,0 +1,64 @@
+# Azure Container Apps Deployment
+
+A production-ready, single-region (UK South) deployment for the Rocket.Chat observability stack.
+
+## What this deploys
+- Azure Container Registry (Basic, admin enabled)
+- Container Apps Environment + Log Analytics
+- Container Apps: rocketchat (external), grafana (internal), mongo, nats, prometheus, mongodb-exporter, nats-exporter
+- ACA Job: `mongo-init-replica` (manual trigger)
+- Single-ingress model: `/` → Rocket.Chat, `/grafana` → internal Grafana
+
+## Quick start
+```bash
+# 1) Set a strong password for Grafana admin
+export GRAFANA_ADMIN_PASSWORD='change-me'
+
+# 2) Deploy end-to-end (imports images, runs job, adds route)
+./azure/deploy-aca.sh
+```
+
+## Manual deployment
+```bash
+# Resource group
+az group create -n Rocketchat_RG -l uksouth
+
+# Deploy Bicep
+az deployment group create \
+  -g Rocketchat_RG \
+  --template-file azure/main.bicep \
+  --parameters location=uksouth domain=chat.canepro.me grafanaAdminPassword="$GRAFANA_ADMIN_PASSWORD"
+
+# Discover ACR
+ACR=$(az acr list -g Rocketchat_RG --query "[0].name" -o tsv)
+
+# Import images
+az acr import -n $ACR --source docker.io/rocketchat/rocket.chat:6.5.4 --image rocketchat:latest
+az acr import -n $ACR --source docker.io/grafana/grafana:12.0.2      --image grafana:latest
+az acr import -n $ACR --source docker.io/bitnami/mongodb:7.0         --image mongo:latest
+az acr import -n $ACR --source docker.io/prom/prometheus:v3.4.2      --image prometheus:latest
+az acr import -n $ACR --source docker.io/nats:2.10-alpine            --image nats:latest
+az acr import -n $ACR --source docker.io/bitnami/mongodb-exporter:0.40.0 --image mongodb-exporter:latest
+az acr import -n $ACR --source docker.io/natsio/prometheus-nats-exporter:0.14.0 --image nats-exporter:latest
+
+# Run one-time init
+az containerapp job start -g Rocketchat_RG -n mongo-init-replica
+
+# Add route (if supported by your CLI)
+az containerapp ingress route add \
+  -g Rocketchat_RG \
+  -n rocketchat \
+  --app-endpoint /grafana \
+  --service grafana \
+  --service-port 3000 \
+  --rewrite-target /
+```
+
+## DNS (Cloudflare)
+- Create CNAME: `chat.canepro.me` → `rocketchat` FQDN printed by the script/CLI
+- SSL/TLS: Full (strict) recommended
+
+## Notes
+- Node Exporter is intentionally omitted (not applicable to ACA)
+- Grafana admin password is stored as an ACA secret
+- Azure Monitor datasource is provisioned via `files/grafana/provisioning/datasources/azure.yml`

--- a/azure/README.md
+++ b/azure/README.md
@@ -9,6 +9,20 @@ A production-ready, single-region (UK South) deployment for the Rocket.Chat obse
 - ACA Job: `mongo-init-replica` (manual trigger)
 - Single-ingress model: `/` → Rocket.Chat, `/grafana` → internal Grafana
 
+## GitHub Actions (optional, recommended)
+Two workflows are provided:
+- `.github/workflows/aca-deploy.yml`: Deploy full stack (manual input `rocketchat_tag`, default 7.9.2)
+- `.github/workflows/aca-update-rocketchat.yml`: Update Rocket.Chat tag (manual or on GitHub Release)
+
+Required repository secrets for OIDC login and passwords:
+- `AZURE_CLIENT_ID` (Federated credential-enabled App Registration)
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `GRAFANA_ADMIN_PASSWORD`
+
+Grant the App Registration the needed roles on resource group `Rocketchat_RG`:
+- `Contributor` (or minimal: `Container App Contributor`, `AcrPull`, `AcrPush`)
+
 ## Quick start
 ```bash
 # 1) Set a strong password for Grafana admin

--- a/azure/TODO.md
+++ b/azure/TODO.md
@@ -1,0 +1,322 @@
+# 🚀 Azure Container Apps Deployment TODO
+
+## 📋 Project Overview
+Deploy RocketChat observability stack to Azure Container Apps (ACA) with Cloudflare integration and multi-region support.
+
+**Target Domain**: `chat.canepro.me`  
+**Budget**: $150/month (Visual Studio Enterprise MPN)  
+**Primary Goal**: Production-ready demo environment with easy access and scalability
+
+---
+
+## 🏗️ **Phase 1: Azure Infrastructure Setup**
+
+### ✅ **Azure Container Apps Environment**
+- [ ] **Create Container Apps Environment**
+  - [ ] Enable "Show environments in all regions" option
+  - [ ] Select optimal region (West US 2 recommended)
+  - [ ] Configure network isolation
+  - [ ] Set up Log Analytics workspace integration
+
+### ✅ **Resource Group & Naming**
+- [ ] **Resource Group**: `Rocketchat_RG`
+- [ ] **Environment Name**: `rocketchat-env-{region}`
+- [ ] **Container App Names**:
+  - `rocketchat-main` (external)
+  - `grafana-monitoring` (external)
+  - `mongo-database` (internal)
+  - `nats-messaging` (internal)
+  - `prometheus-metrics` (internal)
+  - `mongo-exporter` (internal)
+  - `nats-exporter` (internal)
+  - `node-exporter` (internal)
+
+### ✅ **Azure Container Registry (ACR)**
+- [ ] **Create ACR**: `caneprochatacr{unique}`
+- [ ] **Enable admin user** for image access
+- [ ] **Configure image repositories**:
+  - `rocketchat/rocket.chat:6.5.4`
+  - `grafana/grafana:12.0.2`
+  - `bitnami/mongodb:7.0`
+  - `bitnami/mongodb-exporter:0.40.0`
+  - `nats:2.10-alpine`
+  - `natsio/prometheus-nats-exporter:0.14.0`
+  - `prom/prometheus:v3.4.2`
+  - `prom/node-exporter:v1.9.1`
+
+---
+
+## 🌐 **Phase 2: Cloudflare Configuration**
+
+### ✅ **Domain Setup**
+- [ ] **Verify domain ownership**: `chat.canepro.me`
+- [ ] **Enable Cloudflare proxy** (orange cloud)
+- [ ] **Configure SSL/TLS mode**: Full (strict)
+- [ ] **Enable HSTS** for security
+
+### ✅ **DNS Records**
+- [ ] **A Record**: `chat.canepro.me` → Azure Container App IP
+- [ ] **CNAME Record**: `grafana.chat.canepro.me` → `chat.canepro.me` (optional subdomain)
+- [ ] **MX Records**: Configure if email needed
+- [ ] **TXT Records**: For verification and security
+
+### ✅ **Cloudflare Rules & Security**
+- [ ] **Page Rules**:
+  - `chat.canepro.me/grafana*` → Cache Level: Bypass
+  - `chat.canepro.me/api*` → Cache Level: Bypass
+- [ ] **Security Settings**:
+  - [ ] Enable WAF (Web Application Firewall)
+  - [ ] Configure rate limiting
+  - [ ] Set up bot protection
+  - [ ] Enable DDoS protection
+
+### ✅ **Performance Optimization**
+- [ ] **Enable Auto Minify**: JS, CSS, HTML
+- [ ] **Enable Brotli compression**
+- [ ] **Configure caching rules**:
+  - Static assets: 1 day
+  - API responses: 0 seconds
+  - Grafana assets: 1 hour
+
+---
+
+## 🐳 **Phase 3: Container Apps Configuration**
+
+### ✅ **RocketChat Container App**
+- [ ] **Image**: `docker.io/rocketchat/rocket.chat:6.5.4`
+- [ ] **Ingress**: External, port 3000
+- [ ] **Environment Variables**:
+  ```bash
+  MONGO_URL=mongodb://mongo-database:27017/rocketchat?replicaSet=rs0
+  ROOT_URL=https://chat.canepro.me
+  TRANSPORTER=nats://nats-messaging:4222
+  OVERWRITE_SETTING_Prometheus_Enabled=true
+  OVERWRITE_SETTING_Prometheus_Port=9458
+  DEPLOY_PLATFORM=container-apps
+  ```
+- [ ] **Scaling**: 1-3 replicas, HTTP request-based
+- [ ] **Resources**: 1.0 CPU, 2.0 GiB memory
+
+### ✅ **Grafana Container App**
+- [ ] **Image**: `docker.io/grafana/grafana:12.0.2`
+- [ ] **Ingress**: External, port 3000, subpath `/grafana`
+- [ ] **Environment Variables**:
+  ```bash
+  GF_SERVER_ROOT_URL=https://chat.canepro.me/grafana
+  GF_SERVER_SERVE_FROM_SUB_PATH=true
+  GF_SECURITY_ADMIN_PASSWORD=rc-admin
+  GF_AUTH_ANONYMOUS_ENABLED=false
+  ```
+- [ ] **Scaling**: 1-2 replicas
+- [ ] **Resources**: 0.5 CPU, 1.0 GiB memory
+
+### ✅ **MongoDB Container App (Internal)**
+- [ ] **Image**: `docker.io/bitnami/mongodb:7.0`
+- [ ] **Ingress**: Disabled (internal only)
+- [ ] **Environment Variables**:
+  ```bash
+  ALLOW_EMPTY_PASSWORD=yes
+  MONGODB_REPLICA_SET_MODE=primary
+  MONGODB_REPLICA_SET_NAME=rs0
+  ```
+- [ ] **Scaling**: 1 replica (fixed)
+- [ ] **Resources**: 1.0 CPU, 2.0 GiB memory
+- [ ] **Persistent Storage**: Configure if needed
+
+### ✅ **NATS Container App (Internal)**
+- [ ] **Image**: `docker.io/nats:2.10-alpine`
+- [ ] **Ingress**: Disabled (internal only)
+- [ ] **Command**: `--http_port 8222`
+- [ ] **Scaling**: 1 replica (fixed)
+- [ ] **Resources**: 0.5 CPU, 1.0 GiB memory
+
+### ✅ **Prometheus Container App (Internal)**
+- [ ] **Image**: `docker.io/prom/prometheus:v3.4.2`
+- [ ] **Ingress**: Disabled (internal only)
+- [ ] **Configuration**: Mount prometheus.yml
+- [ ] **Scaling**: 1 replica (fixed)
+- [ ] **Resources**: 0.5 CPU, 1.0 GiB memory
+
+### ✅ **Exporters (Internal)**
+- [ ] **MongoDB Exporter**: `bitnami/mongodb-exporter:0.40.0`
+- [ ] **NATS Exporter**: `natsio/prometheus-nats-exporter:0.14.0`
+- [ ] **Node Exporter**: `prom/node-exporter:v1.9.1`
+
+---
+
+## 🔧 **Phase 4: Infrastructure as Code (Bicep)**
+
+### ✅ **Create Bicep Templates**
+- [ ] **main.bicep**: Main deployment template
+- [ ] **parameters.bicep**: Parameter definitions
+- [ ] **modules/**: Reusable modules
+  - [ ] `container-apps.bicep`
+  - [ ] `monitoring.bicep`
+  - [ ] `networking.bicep`
+
+### ✅ **Deployment Scripts**
+- [ ] **deploy.sh**: Linux/macOS deployment script
+- [ ] **deploy.ps1**: Windows PowerShell deployment script
+- [ ] **validate.sh**: Template validation script
+
+### ✅ **Configuration Files**
+- [ ] **prometheus.yml**: Prometheus scrape configuration
+- [ ] **grafana-provisioning/**: Grafana dashboards and datasources
+- [ ] **environment variables**: All service configurations
+
+---
+
+## 🔒 **Phase 5: Security & Monitoring**
+
+### ✅ **Azure Security**
+- [ ] **Managed Identity**: Configure for secure access
+- [ ] **Key Vault**: Store sensitive configuration
+- [ ] **Network Security**: Container Apps Environment isolation
+- [ ] **RBAC**: Proper access control
+
+### ✅ **Monitoring Setup**
+- [ ] **Azure Monitor**: Application Insights integration
+- [ ] **Log Analytics**: Centralized logging
+- [ ] **Alerts**: Set up monitoring alerts
+- [ ] **Dashboards**: Azure Monitor dashboards
+
+### ✅ **Backup Strategy**
+- [ ] **MongoDB Backup**: Automated backup solution
+- [ ] **Configuration Backup**: Infrastructure state backup
+- [ ] **Disaster Recovery**: Recovery procedures
+
+---
+
+## 🚀 **Phase 6: Deployment & Testing**
+
+### ✅ **Pre-deployment Checklist**
+- [ ] **Azure CLI**: Install and authenticate
+- [ ] **Bicep CLI**: Install and verify
+- [ ] **Domain**: Verify Cloudflare configuration
+- [ ] **Budget**: Confirm subscription limits
+
+### ✅ **Deployment Steps**
+- [ ] **Resource Group**: Create `Rocketchat_RG`
+- [ ] **Container Registry**: Deploy ACR
+- [ ] **Environment**: Create Container Apps Environment
+- [ ] **Services**: Deploy all container apps
+- [ ] **DNS**: Configure Cloudflare records
+- [ ] **SSL**: Verify HTTPS certificates
+
+### ✅ **Post-deployment Testing**
+- [ ] **RocketChat**: Create admin account, test functionality
+- [ ] **Grafana**: Login, verify dashboards
+- [ ] **MongoDB**: Test database connectivity
+- [ ] **Monitoring**: Verify metrics collection
+- [ ] **Performance**: Load testing
+- [ ] **Security**: Security scan
+
+---
+
+## 📊 **Phase 7: Cost Optimization**
+
+### ✅ **Resource Optimization**
+- [ ] **Right-sizing**: Optimize CPU/memory allocation
+- [ ] **Scaling rules**: Fine-tune auto-scaling
+- [ ] **Storage**: Optimize persistent storage usage
+- [ ] **Networking**: Minimize data transfer costs
+
+### ✅ **Monitoring Costs**
+- [ ] **Budget alerts**: Set up spending alerts
+- [ ] **Cost analysis**: Regular cost reviews
+- [ ] **Optimization**: Continuous improvement
+
+---
+
+## 📚 **Phase 8: Documentation**
+
+### ✅ **Technical Documentation**
+- [ ] **Deployment Guide**: Step-by-step instructions
+- [ ] **Architecture Diagram**: Visual representation
+- [ ] **Configuration Guide**: Environment setup
+- [ ] **Troubleshooting Guide**: Common issues and solutions
+
+### ✅ **User Documentation**
+- [ ] **Admin Guide**: RocketChat administration
+- [ ] **User Guide**: End-user instructions
+- [ ] **API Documentation**: Integration guide
+- [ ] **Monitoring Guide**: Grafana dashboard usage
+
+---
+
+## 🔄 **Phase 9: Maintenance & Updates**
+
+### ✅ **Update Strategy**
+- [ ] **Image updates**: Regular security updates
+- [ ] **Infrastructure updates**: Bicep template updates
+- [ ] **Configuration updates**: Environment variable updates
+- [ ] **Rollback procedures**: Safe update rollback
+
+### ✅ **Monitoring & Maintenance**
+- [ ] **Health checks**: Regular service health monitoring
+- [ ] **Log analysis**: Regular log review
+- [ ] **Performance tuning**: Continuous optimization
+- [ ] **Security updates**: Regular security patches
+
+---
+
+## 🎯 **Success Criteria**
+
+### ✅ **Functional Requirements**
+- [ ] RocketChat accessible at `https://chat.canepro.me`
+- [ ] Grafana accessible at `https://chat.canepro.me/grafana`
+- [ ] All monitoring metrics collected and displayed
+- [ ] MongoDB replica set properly initialized
+- [ ] Auto-scaling working correctly
+
+### ✅ **Non-Functional Requirements**
+- [ ] Response time < 2 seconds for main pages
+- [ ] 99.9% uptime target
+- [ ] Cost within $150/month budget
+- [ ] Security compliance (HTTPS, WAF, etc.)
+- [ ] Easy management and monitoring
+
+---
+
+## 📝 **Notes & Considerations**
+
+### 🔍 **Multi-Region Environment**
+- **"Show environments in all regions"** option enables:
+  - Better availability across regions
+  - Potential for geo-distribution
+  - Disaster recovery options
+  - **Note**: May increase costs and complexity
+
+### 🌐 **Cloudflare Integration Benefits**
+- **Performance**: Global CDN and caching
+- **Security**: DDoS protection and WAF
+- **SSL**: Automatic SSL certificate management
+- **Analytics**: Traffic and performance insights
+
+### 💰 **Cost Management**
+- **Monitor usage**: Regular cost reviews
+- **Optimize resources**: Right-size containers
+- **Use reserved instances**: For predictable workloads
+- **Budget alerts**: Prevent overspending
+
+---
+
+## 🚨 **Risk Mitigation**
+
+### ⚠️ **Potential Risks**
+- **Cost overruns**: Set budget alerts and monitor usage
+- **Service downtime**: Implement health checks and monitoring
+- **Data loss**: Regular backups and disaster recovery
+- **Security breaches**: Regular security updates and monitoring
+
+### 🛡️ **Mitigation Strategies**
+- **Automated monitoring**: Proactive issue detection
+- **Regular backups**: Data protection
+- **Security best practices**: Regular security reviews
+- **Documentation**: Clear procedures and runbooks
+
+---
+
+**Last Updated**: $(date)  
+**Status**: 🚧 In Progress  
+**Next Milestone**: Azure Infrastructure Setup

--- a/azure/deploy-aca.sh
+++ b/azure/deploy-aca.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Azure Container Apps deployment script (single region: UK South)
+# Usage:
+#   GRAFANA_ADMIN_PASSWORD='change-me' ./azure/deploy-aca.sh
+
+RG="Rocketchat_RG"
+LOCATION="uksouth"
+DOMAIN="chat.canepro.me"
+
+require() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found"; exit 1; }; }
+require az
+
+if ! az account show >/dev/null 2>&1; then
+  echo "Please run: az login"
+  exit 1
+fi
+
+if [[ -z "${GRAFANA_ADMIN_PASSWORD:-}" ]]; then
+  echo "ERROR: GRAFANA_ADMIN_PASSWORD env var is required" >&2
+  exit 1
+fi
+
+echo "==> Creating resource group ($RG)"
+az group create --name "$RG" --location "$LOCATION" 1>/dev/null
+
+echo "==> Deploying Bicep template"
+az deployment group create \
+  --resource-group "$RG" \
+  --template-file azure/main.bicep \
+  --parameters location="$LOCATION" domain="$DOMAIN" grafanaAdminPassword="$GRAFANA_ADMIN_PASSWORD"
+
+echo "==> Discovering ACR"
+ACR_NAME=$(az acr list -g "$RG" --query "[0].name" -o tsv)
+ACR_SERVER=$(az acr show -n "$ACR_NAME" --query loginServer -o tsv)
+
+echo "==> Importing images into $ACR_NAME"
+az acr import -n "$ACR_NAME" --source docker.io/rocketchat/rocket.chat:6.5.4 --image rocketchat:latest
+az acr import -n "$ACR_NAME" --source docker.io/grafana/grafana:12.0.2      --image grafana:latest
+az acr import -n "$ACR_NAME" --source docker.io/bitnami/mongodb:7.0         --image mongo:latest
+az acr import -n "$ACR_NAME" --source docker.io/prom/prometheus:v3.4.2      --image prometheus:latest
+az acr import -n "$ACR_NAME" --source docker.io/nats:2.10-alpine            --image nats:latest
+az acr import -n "$ACR_NAME" --source docker.io/bitnami/mongodb-exporter:0.40.0 --image mongodb-exporter:latest
+az acr import -n "$ACR_NAME" --source docker.io/natsio/prometheus-nats-exporter:0.14.0 --image nats-exporter:latest
+
+echo "==> Starting Mongo init job"
+az containerapp job start --resource-group "$RG" --name mongo-init-replica || true
+
+FQDN=$(az containerapp show -g "$RG" -n rocketchat --query properties.configuration.ingress.fqdn -o tsv)
+echo "==> Rocket.Chat FQDN: https://$FQDN"
+
+echo "==> Attempting to add /grafana route to internal app"
+set +e
+az containerapp ingress route add \
+  --resource-group "$RG" \
+  --name rocketchat \
+  --app-endpoint /grafana \
+  --service grafana \
+  --service-port 3000 \
+  --rewrite-target / >/dev/null 2>&1
+RC=$?
+set -e
+if [[ $RC -ne 0 ]]; then
+  echo "WARNING: CLI route command unavailable or failed. If /grafana 404s, update routes via Portal or latest CLI."
+fi
+
+echo "==> Done. Configure Cloudflare CNAME: chat.canepro.me -> $FQDN"

--- a/azure/main.bicep
+++ b/azure/main.bicep
@@ -19,6 +19,9 @@ param grafanaAdminPassword string = 'rc-admin'
 @description('MongoDB replica set name')
 param mongoReplicaSetName string = 'rs0'
 
+@description('Rocket.Chat image tag (e.g., 7.9.3). Defaults to latest.')
+param rocketchatImageTag string = 'latest'
+
 @description('Container Registry name (lowercase, globally unique). Will be created if it does not exist.')
 param acrName string = toLower('rcobs${uniqueString(resourceGroup().id)}')
 
@@ -361,7 +364,7 @@ resource rocketchat 'Microsoft.App/containerApps@2023-05-01' = {
 			containers: [
 				{
 					name: 'rocketchat'
-					image: '${acrServer}/rocketchat:latest'
+					image: '${acrServer}/rocketchat:${rocketchatImageTag}'
 					env: [
 						{ name: 'MONGO_URL', value: 'mongodb://mongo:27017/rocketchat?replicaSet=${mongoReplicaSetName}' },
 						{ name: 'ROOT_URL', value: 'https://${domain}' },

--- a/azure/main.bicep
+++ b/azure/main.bicep
@@ -1,0 +1,438 @@
+targetScope = 'resourceGroup'
+
+@description('Azure region to deploy to.')
+param location string = 'uksouth'
+
+@description('Resource group name (informational).')
+param resourceGroupName string = 'Rocketchat_RG'
+
+@description('Container Apps Environment name')
+param environmentName string = 'rocketchat-env'
+
+@description('DNS domain used by Rocket.Chat')
+param domain string = 'chat.canepro.me'
+
+@description('Grafana admin password stored as an ACA secret')
+@secure()
+param grafanaAdminPassword string = 'rc-admin'
+
+@description('MongoDB replica set name')
+param mongoReplicaSetName string = 'rs0'
+
+@description('Container Registry name (lowercase, globally unique). Will be created if it does not exist.')
+param acrName string = toLower('rcobs${uniqueString(resourceGroup().id)}')
+
+// ---------------------------------------------
+// Logging - Log Analytics Workspace
+// ---------------------------------------------
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+	name: 'rc-logs-${uniqueString(resourceGroup().id)}'
+	location: location
+	properties: {
+		retentionInDays: 30
+		sku: {
+			name: 'PerGB2018'
+		}
+	}
+}
+
+// ---------------------------------------------
+// Azure Container Registry (Basic, admin enabled)
+// ---------------------------------------------
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+	name: acrName
+	location: location
+	sku: {
+		name: 'Basic'
+	}
+	properties: {
+		adminUserEnabled: true
+	}
+}
+
+var acrCreds = listCredentials(acr.id, '2023-07-01')
+var acrServer = acr.properties.loginServer
+var acrUser = acrCreds.username
+var acrPwd  = acrCreds.passwords[0].value
+
+// ---------------------------------------------
+// Container Apps Environment
+// ---------------------------------------------
+resource cae 'Microsoft.App/managedEnvironments@2023-05-01' = {
+	name: environmentName
+	location: location
+	properties: {
+		appLogsConfiguration: {
+			destination: 'log-analytics'
+			logAnalyticsConfiguration: {
+				customerId: logAnalytics.properties.customerId
+				sharedKey: logAnalytics.listKeys().primarySharedKey
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// Common config helpers
+// ---------------------------------------------
+var commonSecrets = [
+	{
+		name: 'acr-pwd'
+		value: acrPwd
+	}
+]
+
+var commonRegistries = [
+	{
+		server: acrServer
+		username: acrUser
+		passwordSecretRef: 'acr-pwd'
+	}
+]
+
+// ---------------------------------------------
+// mongo (internal)
+// ---------------------------------------------
+resource mongo 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'mongo'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: commonSecrets
+			registries: commonRegistries
+			ingress: {
+				external: false
+				targetPort: 27017
+				transport: 'auto'
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'mongo'
+					image: '${acrServer}/mongo:latest'
+					env: [
+						{ name: 'ALLOW_EMPTY_PASSWORD', value: 'yes' }
+						{ name: 'MONGODB_REPLICA_SET_MODE', value: 'primary' }
+						{ name: 'MONGODB_REPLICA_SET_NAME', value: mongoReplicaSetName }
+					]
+					resources: {
+						cpu: 1.0
+						memory: '2.0Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 1
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// nats (internal)
+// ---------------------------------------------
+resource nats 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'nats'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: commonSecrets
+			registries: commonRegistries
+			ingress: {
+				external: false
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'nats'
+					image: '${acrServer}/nats:latest'
+					command: [ '--http_port', '8222' ]
+					resources: {
+						cpu: 0.5
+						memory: '1.0Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 1
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// mongodb-exporter (internal)
+// ---------------------------------------------
+resource mongodbExporter 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'mongodb-exporter'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: commonSecrets
+			registries: commonRegistries
+			ingress: {
+				external: false
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'mongodb-exporter'
+					image: '${acrServer}/mongodb-exporter:latest'
+					env: [ { name: 'MONGODB_URI', value: 'mongodb://mongo:27017' } ]
+					resources: {
+						cpu: 0.25
+						memory: '0.5Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 1
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// nats-exporter (internal)
+// ---------------------------------------------
+resource natsExporter 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'nats-exporter'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: commonSecrets
+			registries: commonRegistries
+			ingress: {
+				external: false
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'nats-exporter'
+					image: '${acrServer}/nats-exporter:latest'
+					command: [ '-varz', '-connz', 'http://nats:8222' ]
+					resources: {
+						cpu: 0.25
+						memory: '0.5Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 1
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// prometheus (internal)
+// ---------------------------------------------
+resource prometheus 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'prometheus'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: commonSecrets
+			registries: commonRegistries
+			ingress: {
+				external: false
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'prometheus'
+					image: '${acrServer}/prometheus:latest'
+					command: [
+						'--web.console.templates=/usr/share/prometheus/consoles',
+						'--config.file=/etc/prometheus/prometheus.yml',
+						'--web.enable-lifecycle',
+						'--web.listen-address=:9090',
+						'--storage.tsdb.path=/prometheus/data',
+						'--config.auto-reload-interval=30s',
+						'--auto-gomaxprocs',
+						'--storage.tsdb.retention.size=15GB',
+						'--storage.tsdb.retention.time=15d'
+					]
+					resources: {
+						cpu: 0.5
+						memory: '1.0Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 1
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// grafana (internal; secret for admin password)
+// ---------------------------------------------
+resource grafana 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'grafana'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: union(commonSecrets, [ { name: 'grafana-admin-password', value: grafanaAdminPassword } ])
+			registries: commonRegistries
+			ingress: {
+				external: false
+				targetPort: 3000
+				transport: 'auto'
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'grafana'
+					image: '${acrServer}/grafana:latest'
+					env: [
+						{ name: 'GF_SERVER_ROOT_URL', value: 'https://${domain}/grafana' },
+						{ name: 'GF_SERVER_SERVE_FROM_SUB_PATH', value: 'true' },
+						{ name: 'GF_SECURITY_ADMIN_PASSWORD', secretRef: 'grafana-admin-password' }
+					]
+					resources: {
+						cpu: 0.5
+						memory: '1.0Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 2
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// rocketchat (single external ingress).
+// NOTE: Path-based routing to internal Grafana is defined via routes/backends.
+// ---------------------------------------------
+resource rocketchat 'Microsoft.App/containerApps@2023-05-01' = {
+	name: 'rocketchat'
+	location: location
+	properties: {
+		managedEnvironmentId: cae.id
+		configuration: {
+			secrets: commonSecrets
+			registries: commonRegistries
+			ingress: {
+				external: true
+				targetPort: 3000
+				transport: 'auto'
+				traffic: [ { latestRevision: true, weight: 100 } ]
+				// The following routes/backends are available in newer ACA API versions.
+				// If your subscription doesn't support this yet, configure the routes via Azure CLI after deployment:
+				// az containerapp ingress route add --name rocketchat --resource-group ${resourceGroupName} --app-endpoint /grafana --service grafana --service-port 3000 --rewrite-target /
+				//
+				// routes: [
+				//   {
+				//     name: 'grafana'
+				//     match: [ { path: '/grafana(/|$)(.*)' } ]
+				//     destination: 'grafana-backend'
+				//     rewrite: '/$2'
+				//   }
+				// ]
+				// backends: [
+				//   { name: 'rocketchat-backend', service: 'rocketchat', port: 3000 },
+				//   { name: 'grafana-backend', service: 'grafana', port: 3000 }
+				// ]
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'rocketchat'
+					image: '${acrServer}/rocketchat:latest'
+					env: [
+						{ name: 'MONGO_URL', value: 'mongodb://mongo:27017/rocketchat?replicaSet=${mongoReplicaSetName}' },
+						{ name: 'ROOT_URL', value: 'https://${domain}' },
+						{ name: 'TRANSPORTER', value: 'nats://nats:4222' },
+						{ name: 'OVERWRITE_SETTING_Prometheus_Enabled', value: 'true' },
+						{ name: 'OVERWRITE_SETTING_Prometheus_Port', value: '9458' }
+					]
+					resources: {
+						cpu: 1.0
+						memory: '2.0Gi'
+					}
+				}
+			]
+			scale: {
+				minReplicas: 1
+				maxReplicas: 3
+				rules: [
+					{
+						name: 'http-concurrency'
+						http: {
+							metadata: {
+								concurrentRequests: '10'
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+}
+
+// ---------------------------------------------
+// ACA Job: mongo-init-replica (manual trigger)
+// ---------------------------------------------
+resource mongoInitJob 'Microsoft.App/jobs@2023-05-01' = {
+	name: 'mongo-init-replica'
+	location: location
+	properties: {
+		environmentId: cae.id
+		configuration: {
+			triggerType: 'Manual'
+			replicaRetryLimit: 1
+			manualTriggerConfig: {
+				parallelism: 1
+				replicaCompletionCount: 1
+			}
+		}
+		template: {
+			containers: [
+				{
+					name: 'mongo-init'
+					image: '${acrServer}/mongo:latest'
+					resources: {
+						cpu: 0.5
+						memory: '1.0Gi'
+					}
+					command: [
+						'bash',
+						'-lc',
+						"sleep 10; echo 'Initializing MongoDB replica set (if needed)...'; mongosh --host mongo --port 27017 --eval 'try { const s = rs.status(); if (s.ok === 1) { print(\"Replica set already initialized\"); quit(0); } } catch (e) { } rs.initiate({ _id: \"${mongoReplicaSetName}\", members: [ { _id: 0, host: \"mongo:27017\" } ] });' || true"
+					]
+				}
+			]
+		}
+	}
+}
+
+// ---------------------------------------------
+// Outputs
+// ---------------------------------------------
+output containerRegistryName string = acr.name
+output containerRegistryLoginServer string = acrServer
+output environmentId string = cae.id
+output rocketchatFqdn string = rocketchat.properties.configuration.ingress.fqdn

--- a/azure/update-rocketchat.sh
+++ b/azure/update-rocketchat.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage examples:
+#   ./azure/update-rocketchat.sh 7.9.3
+#   ./azure/update-rocketchat.sh 9.10.0 --canary 10      # 10% traffic to new revision
+#   ./azure/update-rocketchat.sh rollback <REVISION_NAME>
+
+RG="Rocketchat_RG"
+
+require() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: $1 not found"; exit 1; }; }
+require az
+
+if ! az account show >/dev/null 2>&1; then
+  echo "Please run: az login"
+  exit 1
+fi
+
+mode="update"
+percent=""
+case "${1:-}" in
+  rollback)
+    mode="rollback"
+    REV="${2:-}"
+    [[ -z "$REV" ]] && { echo "Usage: $0 rollback <REVISION_NAME>"; exit 1; }
+    ;;
+  "")
+    echo "Usage: $0 <image-tag> [--canary <percent>] | rollback <REVISION_NAME>"; exit 1 ;;
+  *)
+    TAG="$1"
+    shift || true
+    ;;
+ esac
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --canary)
+      percent="$2"; shift 2;;
+    *) echo "Unknown arg: $1"; exit 1;;
+  esac
+done
+
+if [[ "$mode" == "rollback" ]]; then
+  echo "==> Routing 100% traffic to revision: $REV"
+  az containerapp ingress traffic set -g "$RG" -n rocketchat --revision-weight "$REV"=100
+  exit 0
+fi
+
+# Discover ACR
+ACR_NAME=$(az acr list -g "$RG" --query "[0].name" -o tsv)
+ACR_SERVER=$(az acr show -n "$ACR_NAME" --query loginServer -o tsv)
+
+# Import target image if missing
+if ! az acr repository show -n "$ACR_NAME" --image "rocketchat:$TAG" >/dev/null 2>&1; then
+  echo "==> Importing rocketchat:$TAG into $ACR_NAME"
+  az acr import -n "$ACR_NAME" --source "docker.io/rocketchat/rocket.chat:$TAG" --image "rocketchat:$TAG"
+fi
+
+echo "==> Updating container app to image: $ACR_SERVER/rocketchat:$TAG"
+az containerapp update -g "$RG" -n rocketchat --image "$ACR_SERVER/rocketchat:$TAG"
+
+if [[ -n "$percent" ]]; then
+  echo "==> Enabling canary: latest=$percent%"
+  az containerapp revision set-mode -g "$RG" -n rocketchat --mode multiple
+  az containerapp ingress traffic set -g "$RG" -n rocketchat --revision-weight latest=$percent
+  echo "Done. Use this to promote:"
+  echo "  az containerapp ingress traffic set -g $RG -n rocketchat --revision-weight latest=100"
+fi

--- a/files/grafana/provisioning/datasources/azure.yml
+++ b/files/grafana/provisioning/datasources/azure.yml
@@ -1,0 +1,14 @@
+# files/grafana/provisioning/datasources/azure.yml
+apiVersion: 1
+datasources:
+  - name: Azure Monitor
+    type: azuremonitor
+    access: proxy
+    jsonData:
+      cloudName: 'AzureCloud'
+      tenantId: '$AZURE_TENANT_ID'
+      clientId: '$AZURE_CLIENT_ID'
+      subscriptionId: '$AZURE_SUBSCRIPTION_ID'
+    secureJsonData:
+      clientSecret: '$AZURE_CLIENT_SECRET'
+    isDefault: false


### PR DESCRIPTION
Summary
- Add production-ready ACA deployment (UK South) via azure/main.bicep
- Single-ingress model: public rocketchat; internal grafana served at /grafana
- ACA Job for Mongo replica-set init
- Grafana admin password as ACA secret
- Azure Monitor datasource provisioned (files/grafana/provisioning/datasources/azure.yml)
- Deployment script azure/deploy-aca.sh for one-command rollout
- Documentation updates: root README quick-start, azure/README, troubleshooting

Impact
- No changes to compose files or local workflow
- All changes additive under azure/ + docs

Post-merge
- From a machine with Azure access: export GRAFANA_ADMIN_PASSWORD and run ./azure/deploy-aca.sh
- Configure Cloudflare CNAME: chat.canepro.me -> rocketchat FQDN printed by script

Notes
- If CLI lacks ingress route support, add the /grafana route in the Azure Portal after deploy.